### PR TITLE
Fix potential crash issue with CraftingRecipeFinder

### DIFF
--- a/ItemSearchPlugin/AddressResolver.cs
+++ b/ItemSearchPlugin/AddressResolver.cs
@@ -11,7 +11,7 @@ namespace ItemSearchPlugin {
 
         public IntPtr GetUIObject { get; private set; }
         public IntPtr GetAgentObject { get; private set; }
-        public IntPtr OpenRecipeLog { get; private set; }
+        public IntPtr SearchItemByCraftingMethod { get; private set; }
 
         protected override void Setup64Bit(SigScanner sig) {
             this.TryOn = sig.ScanText("E8 ?? ?? ?? ?? EB 35 BA ?? ?? ?? ??");
@@ -20,7 +20,7 @@ namespace ItemSearchPlugin {
             this.GetUI2ObjByName = sig.ScanText("e8 ?? ?? ?? ?? 48 8b cf 48 89 87 ?? ?? 00 00 e8 ?? ?? ?? ?? 41 b8 01 00 00 00");
             this.GetUIObject = sig.ScanText("E8 ?? ?? ?? ?? 48 8B C8 48 8B 10 FF 52 40 80 88 ?? ?? ?? ?? 01 E9");
             this.GetAgentObject = sig.ScanText("E8 ?? ?? ?? ?? 8D 56 24");
-            this.OpenRecipeLog = sig.ScanText("E8 ?? ?? ?? ?? 0F B7 CF B8 ?? ?? ?? ??");
+            this.SearchItemByCraftingMethod = sig.ScanText("E8 ?? ?? ?? ?? EB 7A 48 83 F8 05");
         }
     }
 }

--- a/ItemSearchPlugin/CraftingRecipeFinder.cs
+++ b/ItemSearchPlugin/CraftingRecipeFinder.cs
@@ -29,8 +29,8 @@ namespace ItemSearchPlugin {
         private readonly GetAgentObjectDelegate getAgentObject;
 
         [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-        private delegate void OpenRecipeLogDelegate(IntPtr RecipeAgentObject);
-        private readonly OpenRecipeLogDelegate openRecipeLog;
+        private delegate void SearchItemByCraftingMethodDelegate(IntPtr RecipeAgentObject, uint itemID);
+        private readonly SearchItemByCraftingMethodDelegate searchItemByCraftingMethod;
 
         private readonly ConcurrentQueue<uint> searchQueue = new ConcurrentQueue<uint>();
 
@@ -43,7 +43,7 @@ namespace ItemSearchPlugin {
 
                 getUIObject = Marshal.GetDelegateForFunctionPointer<GetUIObjectDelegate>(Address.GetUIObject);
                 getAgentObject = Marshal.GetDelegateForFunctionPointer<GetAgentObjectDelegate>(Address.GetAgentObject);
-                openRecipeLog = Marshal.GetDelegateForFunctionPointer<OpenRecipeLogDelegate>(Address.OpenRecipeLog);
+                searchItemByCraftingMethod = Marshal.GetDelegateForFunctionPointer<SearchItemByCraftingMethodDelegate>(Address.SearchItemByCraftingMethod);
 
                 plugin.PluginInterface.Framework.OnUpdateEvent += OnFrameworkUpdate;
             } catch (Exception ex) {
@@ -73,9 +73,7 @@ namespace ItemSearchPlugin {
                     return;
                 }
 
-                openRecipeLog(recipeAgentPtr);
-                Marshal.WriteInt32(recipeAgentPtr, 0x3A8, 3);
-                Marshal.WriteInt32(recipeAgentPtr, 0x3AC, unchecked((int)itemID));
+                searchItemByCraftingMethod(recipeAgentPtr, itemID);
 
             } catch (NullReferenceException) { }
         }

--- a/ItemSearchPlugin/CraftingRecipeFinder.cs
+++ b/ItemSearchPlugin/CraftingRecipeFinder.cs
@@ -73,8 +73,6 @@ namespace ItemSearchPlugin {
                     return;
                 }
 
-                PluginLog.Log("CraftingRecipeFinder ptr trail: {0:X16} {1:X16} {2:X16}", (ulong)uiObjectPtr, (ulong)uiAgentModulePtr, (ulong)recipeAgentPtr);
-
                 openRecipeLog(recipeAgentPtr);
                 Marshal.WriteInt32(recipeAgentPtr, 0x3A8, 3);
                 Marshal.WriteInt32(recipeAgentPtr, 0x3AC, unchecked((int)itemID));


### PR DESCRIPTION
These changes make the method to search for recipes far safer since we want to remove ourselves from writing memory directly and saving offsets for object fields.