### PR TITLE
Allow for collapsing of the search window

### DIFF
--- a/ItemSearchPlugin/ItemSearchWindow.cs
+++ b/ItemSearchPlugin/ItemSearchWindow.cs
@@ -215,7 +215,8 @@ namespace ItemSearchPlugin {
                 
                 PushStyle(ImGuiStyleVar.WindowMinSize, new Vector2(350, 400));
 
-                if (!ImGui.Begin(Loc.Localize("ItemSearchPlguinMainWindowHeader", $"Item Search") + "###itemSearchPluginMainWindow", ref isOpen, ImGuiWindowFlags.NoCollapse)) {
+                ImGui.Begin(Loc.Localize("ItemSearchPlguinMainWindowHeader", $"Item Search") + "###itemSearchPluginMainWindow", ref isOpen, ImGuiWindowFlags.None);
+                if (!isOpen) {
                     ResetStyle();
                     ImGui.End();
                     return false;


### PR DESCRIPTION
Something that has been bothering me for a while, especially when playing with one of the larger UI scales. This change allows the user to collapse the item search window like the other plugin windows to free up some space.