### PR TITLE
Add setting to auto select everything inside the search box

### DIFF
--- a/ItemSearchPlugin/Filters/ItemNameSearchFilter.cs
+++ b/ItemSearchPlugin/Filters/ItemNameSearchFilter.cs
@@ -76,7 +76,8 @@ namespace ItemSearchPlugin.Filters {
             if (PluginConfig.AutoFocus && ImGui.IsWindowAppearing()) {
                 ImGui.SetKeyboardFocusHere();
             }
-            ImGui.InputText("##ItemNameSearchFilter", ref searchText, 256);
+            var selectionMode = PluginConfig.AutoSelectAll ? ImGuiInputTextFlags.AutoSelectAll : ImGuiInputTextFlags.None;
+            ImGui.InputText("##ItemNameSearchFilter", ref searchText, 256, selectionMode);
             ImGui.SameLine();
             ImGui.TextDisabled("(?)");
             if (ImGui.IsItemHovered()) {

--- a/ItemSearchPlugin/ItemSearchPluginConfig.cs
+++ b/ItemSearchPlugin/ItemSearchPluginConfig.cs
@@ -83,6 +83,7 @@ namespace ItemSearchPlugin {
         public bool TryOnEnabled { get; set; } = false;
         public bool PreviewHousingEnabled { get; set; } = false;
         public bool AutoFocus { get; set; } = true;
+        public bool AutoSelectAll { get; set; } = true;
         public bool SuppressTryOnMessage { get; set; } = true;
         public bool TeamcraftForceBrowser { get; set; } = false;
 
@@ -108,6 +109,7 @@ namespace ItemSearchPlugin {
             DisabledFilters = new List<string>();
             PrependFilterListWithCopy = false;
             AutoFocus = true;
+            AutoSelectAll = false;
             HideKofi = false;
             TeamcraftForceBrowser = false;
             SortType = SortType.ItemID;
@@ -192,6 +194,12 @@ namespace ItemSearchPlugin {
             bool autoFocus = AutoFocus;
             if (ImGui.Checkbox(Loc.Localize("ItemSearchConfigAutoFocus", "Auto focus search box"), ref autoFocus)) {
                 AutoFocus = autoFocus;
+                Save();
+            }
+
+            bool autoSelectAll = AutoSelectAll;
+            if (ImGui.Checkbox(Loc.Localize("ItemSearchConfigAutoSelectAll", "Auto select all inside search box"), ref autoSelectAll)) {
+                AutoSelectAll = autoSelectAll;
                 Save();
             }
 


### PR DESCRIPTION
This PR adds a new setting to auto select everything inside the item name search box upon first focus. Helps when searching for multiple things in series.