### PR TITLE
Add multi-slot item filter

### DIFF
--- a/ItemSearchPlugin/ItemSearchPluginConfig.cs
+++ b/ItemSearchPlugin/ItemSearchPluginConfig.cs
@@ -286,7 +286,7 @@ namespace ItemSearchPlugin {
 
             ImGui.Text("Show Filters: ");
 
-            ImGui.BeginChild("###scrollingFilterSelection", new Vector2(0, 260), true);
+            ImGui.BeginChild("###scrollingFilterSelection", new Vector2(0, 285), true);
 
             ImGui.Columns(2, "###itemSearchToggleFilters", false);
             foreach (var (localizationKey, englishName) in FilterNames) {

--- a/ItemSearchPlugin/ItemSearchWindow.cs
+++ b/ItemSearchPlugin/ItemSearchWindow.cs
@@ -136,6 +136,7 @@ namespace ItemSearchPlugin {
                 new BooleanSearchFilter(pluginConfig, "Unique", "Unique", "Not Unique", BooleanSearchFilter.CheckFunc("IsUnique")),
                 new BooleanSearchFilter(pluginConfig, "Tradable", "Tradable", "Not Tradable", BooleanSearchFilter.CheckFunc("IsUntradable", true)),
                 new BooleanSearchFilter(pluginConfig, "Key Item", "Key Item", "Normal Item", ((item, t, f) => !t), ((item, t, f) => !f)),
+                new BooleanSearchFilter(pluginConfig, "Multi-slot", "Multi-slot", "Not Multi-slot", (i, t, f) => (i.EquipSlotCategory.RowId >= 15 && i.EquipSlotCategory.RowId <= 22 && i.EquipSlotCategory.RowId != 17) ? t : f),
                 new BooleanSearchFilter(pluginConfig, "Favourites", "Favourite", "Not Favourite", (i, t, f) => pluginConfig.Favorites.Contains(i.RowId) ? t : f),
                 new BooleanSearchFilter(pluginConfig, "Store Item", "On Store", "Not On Store", (item, t, f) => {
                     if (t) {


### PR DESCRIPTION
Adds a new filter for multi-slot items (i.e. bunny suits, cowls, etc). 

When browsing through items it is very annoying that these items will clear out other items in the fitting room, this filter will solve that issue.