### PR TITLE
Capture up/down keys when window is open (configurable)

### DIFF
--- a/ItemSearchPlugin/Input/KeyboardFrame.cs
+++ b/ItemSearchPlugin/Input/KeyboardFrame.cs
@@ -1,0 +1,16 @@
+﻿using Dalamud.Game.ClientState.Keys;
+using System.Runtime.InteropServices;
+
+namespace ItemSearchPlugin.Input;
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct KeyboardFrame
+{
+    private const int KeyStateLength = 254;
+
+    public byte Unknown1;
+    public fixed uint KeyState[KeyStateLength];
+
+    public void HandleKey(VirtualKey virtualKey)
+        => KeyState[(int)virtualKey] = 0;
+}

--- a/ItemSearchPlugin/Input/UpDownKeyBlocker.cs
+++ b/ItemSearchPlugin/Input/UpDownKeyBlocker.cs
@@ -1,0 +1,40 @@
+﻿using Dalamud.Game;
+using Dalamud.Game.ClientState.Keys;
+using Dalamud.Hooking;
+using Dalamud.Plugin.Services;
+using System;
+using Dalamud.Bindings.ImGui;
+
+namespace ItemSearchPlugin.Input;
+
+public class UpDownKeyBlocker : IDisposable
+{
+    private readonly ItemSearchPluginConfig _pluginConfig;
+    
+    private unsafe delegate void HandleInputDelegate(IntPtr arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4, KeyboardFrame* keyboardState);
+    private readonly Hook<HandleInputDelegate> handleInputHook = null!;
+
+    public unsafe UpDownKeyBlocker(ItemSearchPluginConfig pluginPluginConfig, ISigScanner scanner, IGameInteropProvider hooking)
+    {
+        _pluginConfig = pluginPluginConfig;
+        
+        var inputHandleSig = "E8 ?? ?? ?? ?? ?? 8B ?? ?? ?? ?? 8B 87 ?? ?? ?? ?? 89 45";
+        handleInputHook = hooking.HookFromAddress<HandleInputDelegate>(scanner.ScanText(inputHandleSig), HandleInputDetour);
+        handleInputHook.Enable();
+    }
+
+    public unsafe void HandleInputDetour(IntPtr arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4, KeyboardFrame* keyboardFrame)
+    {
+        handleInputHook.Original(arg1, arg2, arg3, arg4, keyboardFrame);
+
+        if (_pluginConfig.CaptureUpDownKeys) {
+            keyboardFrame->HandleKey(VirtualKey.UP);
+            keyboardFrame->HandleKey(VirtualKey.DOWN);
+        }
+    }
+
+    public void Dispose()
+    {
+        handleInputHook.Dispose();
+    }
+}

--- a/ItemSearchPlugin/ItemSearchPlugin.cs
+++ b/ItemSearchPlugin/ItemSearchPlugin.cs
@@ -34,6 +34,7 @@ namespace ItemSearchPlugin {
         [PluginService] public static IKeyState KeyState { get; private set; } = null!;
         [PluginService] public static IChatGui Chat { get; private set; } = null!;
         [PluginService] public static ISigScanner SigScanner { get; private set; } = null!;
+        [PluginService] public static IGameInteropProvider GameInteropProvider { get; private set; } = null!;
         [PluginService] public static IClientState ClientState { get; private set; } = null!;
         [PluginService] public static IPlayerState PlayerState { get; private set; } = null!;
         [PluginService] public static IGameGui GameGui { get; private set; } = null!;

--- a/ItemSearchPlugin/ItemSearchPluginConfig.cs
+++ b/ItemSearchPlugin/ItemSearchPluginConfig.cs
@@ -37,6 +37,8 @@ namespace ItemSearchPlugin {
         public bool MarketBoardPluginIntegration { get; set; }
 
         public bool ShowLegacyItems { get; set; }
+        
+        public bool CaptureUpDownKeys { get; set; }
 
         public byte SelectedLanguage { get; set; }
 
@@ -103,6 +105,7 @@ namespace ItemSearchPlugin {
             ShowPreviewHousing = false;
             SuppressTryOnMessage = true;
             ShowLegacyItems = false;
+            CaptureUpDownKeys = true;
             DataSite = ItemSearchPlugin.DataSites.FirstOrDefault()?.Name;
             SelectedLanguage = 0;
             DisabledFilters = new List<string>();
@@ -238,6 +241,12 @@ namespace ItemSearchPlugin {
             bool showLegacyItems = ShowLegacyItems;
             if (ImGui.Checkbox(Loc.Localize("ItemSearchConfigShowLegacyItems", "Show Legacy Items"), ref showLegacyItems)) {
                 ShowLegacyItems = showLegacyItems;
+                Save();
+            }            
+            
+            bool captureUpDownKeys = CaptureUpDownKeys;
+            if (ImGui.Checkbox(Loc.Localize("ItemSearchConfigCaptureUpDownKeys", "Capture up/down keys when browsing items"), ref captureUpDownKeys)) {
+                CaptureUpDownKeys = captureUpDownKeys;
                 Save();
             }
 

--- a/ItemSearchPlugin/ItemSearchPluginConfig.cs
+++ b/ItemSearchPlugin/ItemSearchPluginConfig.cs
@@ -245,7 +245,7 @@ namespace ItemSearchPlugin {
             }            
             
             bool captureUpDownKeys = CaptureUpDownKeys;
-            if (ImGui.Checkbox(Loc.Localize("ItemSearchConfigCaptureUpDownKeys", "Capture up/down keys when browsing items"), ref captureUpDownKeys)) {
+            if (ImGui.Checkbox(Loc.Localize("ItemSearchConfigCaptureUpDownKeys", "Capture up/down keys when Item Search window is open"), ref captureUpDownKeys)) {
                 CaptureUpDownKeys = captureUpDownKeys;
                 Save();
             }

--- a/ItemSearchPlugin/ItemSearchWindow.cs
+++ b/ItemSearchPlugin/ItemSearchWindow.cs
@@ -13,8 +13,10 @@ using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using Dalamud.Utility;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Game.ClientState.Keys;
 using ItemSearchPlugin.ActionButtons;
 using ItemSearchPlugin.Filters;
+using ItemSearchPlugin.Input;
 using Lumina.Excel.Sheets;
 
 namespace ItemSearchPlugin {
@@ -31,6 +33,7 @@ namespace ItemSearchPlugin {
         private readonly ItemSearchPluginConfig pluginConfig;
         public List<SearchFilter> SearchFilters;
         public List<IActionButton> ActionButtons;
+        private UpDownKeyBlocker upDownKeyBlocker;
 
         private bool autoTryOn;
         public bool autoPreviewHousing;
@@ -157,6 +160,8 @@ namespace ItemSearchPlugin {
                 new FfxivStoreActionButton(pluginConfig),
                 new CopyItemAsJson(plugin),
             };
+
+            upDownKeyBlocker = new UpDownKeyBlocker(pluginConfig, SigScanner, GameInteropProvider);
         }
 
         private SortType sortType;
@@ -903,8 +908,8 @@ namespace ItemSearchPlugin {
                     }
                 }
 
-                var keyStateDown = ImGui.GetIO().KeysDown[0x28] || KeyState[0x28];
-                var keyStateUp = ImGui.GetIO().KeysDown[0x26] || KeyState[0x26];
+                var keyStateDown = ImGui.GetIO().KeysDown[(int)VirtualKey.DOWN] || KeyState[VirtualKey.DOWN];
+                var keyStateUp = ImGui.GetIO().KeysDown[(int)VirtualKey.UP] || KeyState[VirtualKey.UP];
 
 #if DEBUG
                 // Random up/down if both are pressed
@@ -1002,6 +1007,7 @@ namespace ItemSearchPlugin {
                 b?.Dispose();
             }
 
+            upDownKeyBlocker.Dispose();
         }
     }
 }


### PR DESCRIPTION
When you browse through items with your arrow keys your camera keeps shifting up/down.

* Capture up/down keys whenever Item Search window is open.
* Add it as a config, in case people want to use arrow keys as normal when window is open.

The KeyboardFrame/Hook code was copied from Brio :)